### PR TITLE
イベント参加人数関連の機能追加

### DIFF
--- a/api/app/controllers/api/v1/events_controller.rb
+++ b/api/app/controllers/api/v1/events_controller.rb
@@ -1,7 +1,9 @@
 class Api::V1::EventsController < ApplicationController
   def index
+    # 参加人数を求めるサブクエリ
+    participants_count_sql = Membership.select('count(id)').where('memberships.event_id = events.id').to_sql
     # EventsとUsersテーブルを内部結合して、必要なカラムをselect
-    events = Event.joins(:user).select('events.*, users.name as organizer').order(id: 'DESC')
+    events = Event.joins(:user).select("events.*, users.name as organizer, (#{participants_count_sql}) as participants_count").order(id: 'DESC')
     render json: events, status: :ok
   end
 

--- a/api/app/controllers/api/v1/events_controller.rb
+++ b/api/app/controllers/api/v1/events_controller.rb
@@ -65,7 +65,7 @@ class Api::V1::EventsController < ApplicationController
 
   def event_params
     params.permit(
-      :user_id, :event_name, :event_category, :start_date, :end_date, :prefecture_id, :venue, :explanation, :image
+      :user_id, :event_name, :event_category, :start_date, :end_date, :prefecture_id, :venue, :explanation, :image, :max_participants
     )
   end
 end

--- a/api/app/controllers/api/v1/users_controller.rb
+++ b/api/app/controllers/api/v1/users_controller.rb
@@ -2,8 +2,12 @@ class Api::V1::UsersController < ApplicationController
   # ユーザー情報取得(個別)
   def show
     user = User.find(params[:id])
-    organized_events = user.events.joins(:user).select('events.*, users.name as organizer').order(id: 'DESC')
-    participating_events = user.participating_events.joins(:user).select('events.*, users.name as organizer').order(id: 'DESC')
+
+    # 参加人数を求めるサブクエリ
+    participants_count_sql = Membership.select('count(id)').where('memberships.event_id = events.id').to_sql
+
+    organized_events = user.events.joins(:user).select("events.*, users.name as organizer, (#{participants_count_sql}) as participants_count").order(id: 'DESC')
+    participating_events = user.participating_events.joins(:user).select("events.*, users.name as organizer, (#{participants_count_sql}) as participants_count").order(id: 'DESC')
     is_followed = user.followers.exists?(id: current_api_v1_user.id)
     render json: {
       user: user,

--- a/api/db/migrate/20210927233726_add_column_max_participants_to_events.rb
+++ b/api/db/migrate/20210927233726_add_column_max_participants_to_events.rb
@@ -1,0 +1,5 @@
+class AddColumnMaxParticipantsToEvents < ActiveRecord::Migration[6.0]
+  def change
+    add_column :events, :max_participants, :integer
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_26_004741) do
+ActiveRecord::Schema.define(version: 2021_09_27_233726) do
 
   create_table "events", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -24,6 +24,7 @@ ActiveRecord::Schema.define(version: 2021_09_26_004741) do
     t.string "image"
     t.datetime "start_date"
     t.datetime "end_date"
+    t.integer "max_participants"
     t.index ["user_id"], name: "index_events_on_user_id"
   end
 

--- a/frontend/src/components/organisms/event/eventCard.tsx
+++ b/frontend/src/components/organisms/event/eventCard.tsx
@@ -1,5 +1,5 @@
 import { memo, VFC } from "react";
-import { Box, Icon, Image, Stack, Text, HStack } from "@chakra-ui/react";
+import { Box, Icon, Image, Stack, Text, HStack, VStack, Flex } from "@chakra-ui/react";
 import { MdLocationOn } from "react-icons/md"
 
 type Props = {
@@ -8,11 +8,13 @@ type Props = {
   imageUrl: string;
   eventName: string;
   prefecture: string;
+  maxParticipants: number | undefined;
+  participantsCount: number | undefined;
   onClick: (id: number | undefined, userId: number | undefined) => void;
 };
 
 export const EventCard: VFC<Props> = memo(props => {
-  const { id, userId, imageUrl, eventName, prefecture, onClick } = props;
+  const { id, userId, imageUrl, eventName, prefecture, maxParticipants, participantsCount, onClick } = props;
 
   return (
     <Box
@@ -25,7 +27,7 @@ export const EventCard: VFC<Props> = memo(props => {
       _hover={{ cursor: "pointer", opacity: 0.8 }}
       onClick={() => onClick(id, userId)}
     >
-      <Stack textAlign="center">
+      <VStack>
         <Image
           borderRadius="full"
           boxSize="160px"
@@ -37,14 +39,15 @@ export const EventCard: VFC<Props> = memo(props => {
           {eventName}
         </Text>
         <Box>
-        <HStack textAlign="center">
+        <Flex alignItems="center">
           <Icon as={MdLocationOn} />
           <Text fontSize="sm" color="gray">
             {prefecture}
           </Text>
-        </HStack>
+          <Text ml={5} fontSize="sm">{`${participantsCount}/${maxParticipants}人`}</Text>
+        </Flex>
         </Box>
-      </Stack>
+      </VStack>
     </Box>
   );
 });

--- a/frontend/src/components/pages/CreateEvent.tsx
+++ b/frontend/src/components/pages/CreateEvent.tsx
@@ -36,6 +36,7 @@ export const CreateEvent: VFC = memo(() => {
     formData.append('start_date', startDate);
     formData.append('end_date', endDate);
     formData.append('prefecture_id', `${params.prefecture_id}`);
+    formData.append('max_participants', `${params.max_participants}`);
     formData.append('venue', params.venue);
     formData.append('explanation', params.explanation);
     image && formData.append('image', image ?? ""); //画像が選択されていない時はappendしない。
@@ -102,6 +103,17 @@ export const CreateEvent: VFC = memo(() => {
                   )
                 }
               </Select>
+            </FormControl>
+            <FormControl isInvalid={errors.name}>
+              <FormLabel fontSize="md">参加人数上限</FormLabel>
+              <Input 
+              id="max_participants"
+              type="text"
+              {...register("max_participants",{ required: "参加人数上限は必須入力です" })}
+              w="70px" border="1px" borderColor="gray.400" backgroundColor="gray.100"/> 人
+              <FormErrorMessage>
+                {errors.max_participants && errors.max_participants.message}
+              </FormErrorMessage>
             </FormControl>
             <FormControl>
               <FormLabel fontSize="md">会場</FormLabel>

--- a/frontend/src/components/pages/EditEvent.tsx
+++ b/frontend/src/components/pages/EditEvent.tsx
@@ -47,6 +47,7 @@ export const EditEvent: VFC = memo(() => {
     setValue("start_date", startDate);
     setValue("end_date", endDate);
     setValue("prefecture_id", event?.prefecture_id);
+    setValue("max_participants", event?.max_participants);
     setValue("venue", event?.venue);
     setValue("explanation", event?.explanation);
 
@@ -56,6 +57,7 @@ export const EditEvent: VFC = memo(() => {
       setValue("start_date", startDate);
       setValue("end_date", endDate);
       setValue("prefecture_id", event?.prefecture_id);
+      setValue("max_participants", event?.max_participants);
       setValue("venue", event?.venue);
       setValue("explanation", event?.explanation);
     };
@@ -75,6 +77,7 @@ export const EditEvent: VFC = memo(() => {
     formData.append('start_date', startDate);
     formData.append('end_date', endDate);
     formData.append('prefecture_id', `${params.prefecture_id}`);
+    formData.append('max_participants', `${params.max_participants}`);
     formData.append('venue', params.venue);
     formData.append('explanation', params.explanation);
     image && formData.append('image', image ?? ""); //画像が選択されていない時はappendしない。
@@ -142,6 +145,17 @@ export const EditEvent: VFC = memo(() => {
                   )
                 }
               </Select>
+            </FormControl>
+            <FormControl isInvalid={errors.name}>
+              <FormLabel fontSize="md">参加人数上限</FormLabel>
+              <Input 
+              id="max_participants"
+              type="text"
+              {...register("max_participants",{ required: "参加人数上限は必須入力です" })}
+              w="70px" border="1px" borderColor="gray.400" backgroundColor="gray.100"/> 人
+              <FormErrorMessage>
+                {errors.max_participants && errors.max_participants.message}
+              </FormErrorMessage>
             </FormControl>
             <FormControl>
               <FormLabel fontSize="md">会場</FormLabel>

--- a/frontend/src/components/pages/Home.tsx
+++ b/frontend/src/components/pages/Home.tsx
@@ -24,7 +24,7 @@ export const Home: VFC = memo(() => {
   const { signin } = useSignin();
 
   //ページを開いた時にだけ実行する
-  useEffect(() => getAllEvents(),[getAllEvents])
+  useEffect(() => getAllEvents(),[getAllEvents,isOpen])
 
   //モーダルを開閉するタイミングで実行
   useEffect(() => getCurrentUser,[isOpen])
@@ -116,6 +116,8 @@ export const Home: VFC = memo(() => {
             imageUrl={event.image.url ?? "https://placehold.jp/150x150.png?text=no image"}
             eventName={event.event_name}
             prefecture={event.prefecture_id ? prefectures[event.prefecture_id] : ""}
+            maxParticipants={event.max_participants}
+            participantsCount={event.participants_count}
             onClick={onClickEvent}
           />
         </WrapItem>

--- a/frontend/src/components/pages/Search.tsx
+++ b/frontend/src/components/pages/Search.tsx
@@ -85,6 +85,8 @@ export const Search: VFC = memo(() => {
             imageUrl={event.image.url ?? "https://placehold.jp/150x150.png?text=no image"}
             eventName={event.event_name}
             prefecture={event.prefecture_id ? prefectures[event.prefecture_id] : ""}
+            maxParticipants={event.max_participants}
+            participantsCount={event.participants_count}
             onClick={onClickEvent}
           />
         </WrapItem>

--- a/frontend/src/components/pages/User.tsx
+++ b/frontend/src/components/pages/User.tsx
@@ -117,6 +117,8 @@ export const User: VFC = memo(() => {
                   imageUrl={event.image.url ?? "https://placehold.jp/150x150.png?text=no image"}
                   eventName={event.event_name}
                   prefecture={event.prefecture_id ? prefectures[event.prefecture_id] : ""}
+                  maxParticipants={event.max_participants}
+                  participantsCount={event.participants_count}
                   onClick={onClickEvent}
                 />
               </WrapItem>
@@ -133,6 +135,8 @@ export const User: VFC = memo(() => {
                   imageUrl={event.image.url ?? "https://placehold.jp/150x150.png?text=no image"}
                   eventName={event.event_name}
                   prefecture={event.prefecture_id ? prefectures[event.prefecture_id] : ""}
+                  maxParticipants={event.max_participants}
+                  participantsCount={event.participants_count}
                   onClick={onClickEvent}
                 />
               </WrapItem>

--- a/frontend/src/types/event.ts
+++ b/frontend/src/types/event.ts
@@ -13,4 +13,5 @@ export type Event = {
   },
   max_participants: number;
   organizer?: string;
+  participants_count: number;
 }

--- a/frontend/src/types/event.ts
+++ b/frontend/src/types/event.ts
@@ -11,5 +11,6 @@ export type Event = {
   image: {
     url: string
   },
+  max_participants: number;
   organizer?: string;
 }

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -25,6 +25,7 @@ export type User = {
     start_date: Date;
     end_date: Date;
     max_participants: number;
+    participants_count: number;
     image: {
       url: string
     }
@@ -40,6 +41,7 @@ export type User = {
     start_date: Date;
     end_date: Date;
     max_participants: number;
+    participants_count: number;
     image: {
       url: string
     }

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -24,6 +24,7 @@ export type User = {
     explanation: string;
     start_date: Date;
     end_date: Date;
+    max_participants: number;
     image: {
       url: string
     }
@@ -38,6 +39,7 @@ export type User = {
     explanation: string;
     start_date: Date;
     end_date: Date;
+    max_participants: number;
     image: {
       url: string
     }


### PR DESCRIPTION
・イベント作成/編集画面にて参加人数上限を設定できるように項目を追加しました。
・イベントカードに「2/5人」のような表示を追加し、参加上限数と、現在の参加者数がわかるように変更しました。
![image](https://user-images.githubusercontent.com/26037696/135045074-b922cc0a-f908-4175-8291-0e7e874f7692.png)
