### PR TITLE
イベント詳細画面にコメントが書ける機能を追加

### DIFF
--- a/api/app/controllers/api/v1/comments_controller.rb
+++ b/api/app/controllers/api/v1/comments_controller.rb
@@ -1,6 +1,8 @@
 class Api::V1::CommentsController < ApplicationController
   def show
-    comments = Comment.find(params[:id])
+    comments = User.joins(:comments)
+                   .select('comments.id as comment_id, comments.event_id, comments.user_id, comments.comment, users.id as id,users.name, users.image')
+                   .where("comments.event_id = #{params[:event_id]}").order(comment_id: 'ASC')
     render json: comments, status: :ok
   end
 

--- a/api/app/controllers/api/v1/comments_controller.rb
+++ b/api/app/controllers/api/v1/comments_controller.rb
@@ -1,0 +1,24 @@
+class Api::V1::CommentsController < ApplicationController
+  def show
+    comments = Comment.find(params[:id])
+    render json: comments, status: :ok
+  end
+
+  def create
+    comment = current_api_v1_user.comments.build(event_id: params[:event_id], comment: params[:comment])
+    if comment.save!
+      render json: comment, status: :ok
+    else
+      render json: comment.errors
+    end
+  end
+
+  def destroy
+    comment = Comment.find(params[:id])
+    if comment.destroy!
+      render json: comment, status: :ok
+    else
+      render json: comment.errors
+    end
+  end
+end

--- a/api/app/models/comment.rb
+++ b/api/app/models/comment.rb
@@ -1,0 +1,4 @@
+class Comment < ApplicationRecord
+  belongs_to :event
+  belongs_to :user
+end

--- a/api/app/models/event.rb
+++ b/api/app/models/event.rb
@@ -1,5 +1,6 @@
 class Event < ApplicationRecord
   belongs_to :user
   has_many :memberships, dependent: :destroy
+  has_many :comments, dependent: :destroy
   mount_uploader :image, AvaterUploader # CarrierWaveで作ったクラスと紐付ける
 end

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -3,6 +3,7 @@
 class User < ActiveRecord::Base
   has_many :events, dependent: :destroy
   has_many :memberships, dependent: :destroy
+  has_many :comments, dependent: :destroy
   has_many :participating_events, through: :memberships, source: :event
   has_many :active_relationships, class_name: 'Relationship', foreign_key: :followed_id
   has_many :followings, through: :active_relationships, source: :follower

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :events do
         resource :memberships, only: [:create, :destroy]
-        resource :comments, only: [:show, :create, :destroy]
+        resource :comments, only: [:show, :create]
         get :search, on: :collection
         get :participants, on: :collection
       end
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
         get :followers, on: :member
         get :follows_followers_count, on: :member
       end
+      resources :comments, only: [:destroy]
       mount_devise_token_auth_for 'User', at: 'auth', controllers: {
         registrations: 'api/v1/auth/registrations'
       }
@@ -20,7 +21,7 @@ Rails.application.routes.draw do
       namespace :auth do
         resources :sessions, only: [:index]
       end
-      get :health_check, to: "health_check#index"
+      get :health_check, to: 'health_check#index'
     end
   end
 end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :events do
         resource :memberships, only: [:create, :destroy]
+        resource :comments, only: [:show, :create, :destroy]
         get :search, on: :collection
         get :participants, on: :collection
       end

--- a/api/db/migrate/20211001233626_create_comments.rb
+++ b/api/db/migrate/20211001233626_create_comments.rb
@@ -1,0 +1,11 @@
+class CreateComments < ActiveRecord::Migration[6.0]
+  def change
+    create_table :comments do |t|
+      t.integer :event_id
+      t.integer :user_id
+      t.string :comment
+
+      t.timestamps
+    end
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_28_211916) do
+ActiveRecord::Schema.define(version: 2021_10_01_233626) do
+
+  create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.integer "event_id"
+    t.integer "user_id"
+    t.string "comment"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "events", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.bigint "user_id", null: false

--- a/api/spec/controllers/api/v1/comments_controller_spec.rb
+++ b/api/spec/controllers/api/v1/comments_controller_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::CommentsController, type: :controller do
+
+  describe "GET #index" do
+    it "returns http success" do
+      get :index
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET #create" do
+    it "returns http success" do
+      get :create
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET #destroy" do
+    it "returns http success" do
+      get :destroy
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/api/spec/factories/comments.rb
+++ b/api/spec/factories/comments.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :comment do
+    event_id 1
+    user_id 1
+    comment "MyString"
+  end
+end

--- a/api/spec/models/comment_spec.rb
+++ b/api/spec/models/comment_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Comment, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/frontend/src/components/organisms/event/EventDetailModal.tsx
+++ b/frontend/src/components/organisms/event/EventDetailModal.tsx
@@ -1,5 +1,5 @@
 import { memo, useEffect, VFC } from "react";
-import { Stack, Modal, ModalContent, ModalOverlay, ModalHeader, ModalCloseButton, ModalBody, FormControl, FormLabel, Input, Textarea, Button, Text, Icon, Link, Image, HStack, Box, Divider } from "@chakra-ui/react";
+import { Stack, Modal, ModalContent, ModalOverlay, ModalHeader, ModalCloseButton, ModalBody, FormControl, FormLabel, Input, Textarea, Button, Text, Icon, Link, Image, HStack, Box, Divider, IconButton } from "@chakra-ui/react";
 import { Event } from "../../../types/event";
 import { prefectures } from "../../../data/prefectures";
 import { useMemberships } from "../../../hooks/useMemberships";
@@ -12,6 +12,7 @@ import { useEvents } from "../../../hooks/useEvents";
 import { useComments } from "../../../hooks/useComments";
 import { useForm } from "react-hook-form";
 import { Comment } from "../../../types/comment";
+import { DeleteIcon } from "@chakra-ui/icons";
 
 
 type Props = {
@@ -20,17 +21,18 @@ type Props = {
   isJoined: boolean;
   isOrganizer: boolean;
   isSignedIn: boolean;
+  loginUserId: number | undefined;
   onClose: () => void;
 };
 
 
 export const EventDetailModal: VFC<Props> = memo(props => {
-  const { event, isOpen, onClose, isJoined, isOrganizer, isSignedIn } = props;
+  const { event, isOpen, onClose, isJoined, isOrganizer, isSignedIn, loginUserId } = props;
   const [ buttonSwitch, setButtonSwitch ] = useState<boolean>();
   const [ isFull, setIsFull ] = useState<boolean>(); //定員オーバかどうか
   const { createMemberships, deleteMemberships, loading } = useMemberships();
   const { getParticipants, participants} = useEvents();
-  const { createComments, getComments, isCommented, comments, loadingComment } = useComments();
+  const { createComments, getComments, deleteComments, isEditted, comments, loadingComment } = useComments();
   const history = useHistory();
   const { register, handleSubmit, setValue, formState } = useForm({ mode: "all" });
   
@@ -39,7 +41,7 @@ export const EventDetailModal: VFC<Props> = memo(props => {
     event?.id && getParticipants(`${event?.id}`);
     setIsFull(event?.max_participants === event?.participants_count);
     getComments(event?.id);
-  },[isOpen, isCommented])
+  },[isOpen, isEditted])
 
   const onSubmit = (params: Comment) => {
     if(isSignedIn) {
@@ -68,6 +70,10 @@ export const EventDetailModal: VFC<Props> = memo(props => {
   
   const onClickEdit = () => {
     history.push(`/event/${event?.id}`)
+  };
+
+  const onClickCommentDelete = (id: number) => {
+    deleteComments(id);
   };
 
   const redirectToSignIn = () => {
@@ -157,9 +163,24 @@ export const EventDetailModal: VFC<Props> = memo(props => {
                           />
                         <Box>
                           <Text fontSize="sm">{comment.name}</Text>
-                          <Box px={2} py={1} borderRadius="md" bg="gray.200">
-                            <Text fontSize="xs">{comment.comment}</Text>
-                          </Box>
+                          <HStack>
+                            <Box px={2} py={1} borderRadius="md" bg="gray.200">
+                              <Text fontSize="xs">{comment.comment}</Text>
+                            </Box>
+                            <Box>
+                              {(isOrganizer || comment.user_id === loginUserId) &&
+                                <IconButton
+                                onClick={() => onClickCommentDelete(comment.comment_id)}
+                                isLoading={loadingComment}
+                                variant="link"
+                                color="gray.300"
+                                _hover={{ color: "gray.500" }}
+                                aria-label="Delete comment"
+                                icon={<DeleteIcon />}
+                              />
+                              }
+                            </Box>
+                          </HStack>
                         </Box>
                       </HStack>
                     </Box>

--- a/frontend/src/components/pages/Home.tsx
+++ b/frontend/src/components/pages/Home.tsx
@@ -122,7 +122,7 @@ export const Home: VFC = memo(() => {
         </WrapItem>
       ))}
     </Wrap>
-    <EventDetailModal event={selectedEvent} isOpen={isOpen} onClose={onClose} isJoined={isJoined} isOrganizer={isOrganizer} isSignedIn={auth.isSignedIn}/>
+    <EventDetailModal event={selectedEvent} isOpen={isOpen} onClose={onClose} isJoined={isJoined} isOrganizer={isOrganizer} isSignedIn={auth.isSignedIn} loginUserId={auth.currentUser?.id}/>
     </>
   );
 });

--- a/frontend/src/components/pages/Search.tsx
+++ b/frontend/src/components/pages/Search.tsx
@@ -93,7 +93,7 @@ export const Search: VFC = memo(() => {
       ))}
     </Wrap>
   </Box>
-  <EventDetailModal event={selectedEvent} isOpen={isOpen} onClose={onClose} isJoined={isJoined} isOrganizer={isOrganizer} isSignedIn={auth.isSignedIn}/>
+  <EventDetailModal event={selectedEvent} isOpen={isOpen} onClose={onClose} isJoined={isJoined} isOrganizer={isOrganizer} isSignedIn={auth.isSignedIn} loginUserId={auth.currentUser?.id}/>
   </>
   );
 });

--- a/frontend/src/components/pages/User.tsx
+++ b/frontend/src/components/pages/User.tsx
@@ -148,7 +148,7 @@ export const User: VFC = memo(() => {
         </TabPanels>
       </Tabs>
     </Box>
-    <EventDetailModal event={selectedEvent} isOpen={isOpen} onClose={onClose} isJoined={isJoined} isOrganizer={isOrganizer} isSignedIn={auth.isSignedIn}/>
+    <EventDetailModal event={selectedEvent} isOpen={isOpen} onClose={onClose} isJoined={isJoined} isOrganizer={isOrganizer} isSignedIn={auth.isSignedIn} loginUserId={auth.currentUser?.id}/>
     <AlertDialog isOpen={isOpenDialog} leastDestructiveRef={cancelRef} onClose={onCloseDialog}>
       <AlertDialogOverlay>
         <AlertDialogContent>

--- a/frontend/src/hooks/useComments.ts
+++ b/frontend/src/hooks/useComments.ts
@@ -6,9 +6,9 @@ import { Comment, Comments } from "../types/comment";
 
 export const useComments = () => {
   const axios = axiosBaseUrl;
-  const [loadingComment, setLoading] = useState(false);
-  const [comments, setComments] = useState<Array<Comments>>();
-  const [ isCommented, setIsCommented ] = useState<boolean>(false);
+  const [ loadingComment, setLoading ] = useState(false);
+  const [ comments, setComments ] = useState<Array<Comments>>();
+  const [ isEditted, setIsEditted ] = useState<boolean>(false);
 
   const { showMessage } = useMessage();
 
@@ -19,7 +19,7 @@ export const useComments = () => {
     .then((res) => {
       console.log(res.data);
       setComments(res.data);
-      setIsCommented(false);
+      setIsEditted(false);
     })
     .catch(() => {
       console.log("コメントを取得できませんでした");
@@ -38,7 +38,7 @@ export const useComments = () => {
     }})
     .then((res) => {
       console.log(res.data);
-      setIsCommented(true);
+      setIsEditted(true);
     })
     .catch(() => {
       showMessage({ title: "エラーが発生しました", status: "error" });
@@ -46,5 +46,19 @@ export const useComments = () => {
     .finally(() => setLoading(false));
   },[]);
 
-  return { createComments, getComments, setIsCommented, isCommented, comments, loadingComment }
+  const deleteComments = useCallback((id: number) => {
+    setLoading(true);
+    axios
+    .delete(`/api/v1/comments/${id}`)
+    .then((res) => {
+      console.log(res.data);
+      setIsEditted(true);
+    })
+    .catch(() => {
+      showMessage({ title: "エラーが発生しました", status: "error" });
+    })
+    .finally(() => setLoading(false));
+  },[]);
+
+  return { createComments, getComments, deleteComments, setIsEditted, isEditted, comments, loadingComment }
 };

--- a/frontend/src/hooks/useComments.ts
+++ b/frontend/src/hooks/useComments.ts
@@ -1,0 +1,50 @@
+import axiosBaseUrl from "../config/axiosBaseUrl";
+import { useCallback, useState } from "react";
+import { useMessage } from "./useMessage";
+import Cookies from "js-cookie";
+import { Comment, Comments } from "../types/comment";
+
+export const useComments = () => {
+  const axios = axiosBaseUrl;
+  const [loadingComment, setLoading] = useState(false);
+  const [comments, setComments] = useState<Array<Comments>>();
+  const [ isCommented, setIsCommented ] = useState<boolean>(false);
+
+  const { showMessage } = useMessage();
+
+  const getComments = useCallback((event_id:number | undefined) => {
+    setLoading(true);
+    axios
+    .get<Array<Comments>>(`/api/v1/events/${event_id}/comments`)
+    .then((res) => {
+      console.log(res.data);
+      setComments(res.data);
+      setIsCommented(false);
+    })
+    .catch(() => {
+      console.log("コメントを取得できませんでした");
+    })
+    .finally(() => setLoading(false));
+  },[]);
+
+
+  const createComments = useCallback((params:Comment) => {
+    setLoading(true);
+    axios
+    .post<Comment>(`/api/v1/events/${params.event_id}/comments`, { comment: params.comment }, { headers: {
+      "access-token": Cookies.get("_access_token"),
+      "client": Cookies.get("_client"),
+      "uid": Cookies.get("_uid")
+    }})
+    .then((res) => {
+      console.log(res.data);
+      setIsCommented(true);
+    })
+    .catch(() => {
+      showMessage({ title: "エラーが発生しました", status: "error" });
+    })
+    .finally(() => setLoading(false));
+  },[]);
+
+  return { createComments, getComments, setIsCommented, isCommented, comments, loadingComment }
+};

--- a/frontend/src/types/comment.ts
+++ b/frontend/src/types/comment.ts
@@ -1,0 +1,15 @@
+export type Comment = {
+  event_id: string;
+  comment: string;
+}
+
+export type Comments = {
+  comment_id: number;
+  name: string;
+  image: {
+    url: string;
+  };
+  event_id: number;
+  user_id: number;
+  comment: string;
+}


### PR DESCRIPTION
- イベント詳細画面にコメント表示/投稿/削除機能を追加しました。
  - ゴミ箱のアイコンボタンを押すとコメントが削除されます。
    - コメント削除制御　=> 主催者 : 全コメント削除可能 / コメント投稿者 : 自分の投稿のみ削除可能

- 自分が主催者の場合、全てのコメントに対してゴミ箱アイコンが出ます。

  <img src="https://user-images.githubusercontent.com/26037696/135737222-1b3418c8-5deb-4d65-88de-b186ea78ace9.png" width="200px">

- 主催者ではない場合は、自分のコメントに対してのみゴミ箱アイコンが出ます。

   <img src="https://user-images.githubusercontent.com/26037696/135737279-28dfc5f0-780c-4255-b618-dde0f1ff0bb1.png" width="200px">
