### PR TITLE
バリデーションの修正

### DIFF
--- a/api/app/models/event.rb
+++ b/api/app/models/event.rb
@@ -5,10 +5,10 @@ class Event < ApplicationRecord
 
   validates :user_id, presence: true
   validates :event_name, presence: true, length: { maximum: 50 }
-  validates :event_category, numericality: { only_integer: true }
+  validates :event_category, numericality: { only_integer: true, allow_nil: true }
   validates :start_date, presence: true
   validates :end_date, presence: true
-  validates :prefecture_id, numericality: { only_integer: true, less_than_or_equal_to: 46 }
+  validates :prefecture_id, numericality: { only_integer: true, allow_nil: true, less_than_or_equal_to: 46 }
   validates :max_participants, presence: true, numericality: { only_integer: true, less_than_or_equal_to: 100 }
 
   mount_uploader :image, AvaterUploader # CarrierWaveで作ったクラスと紐付ける

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -13,7 +13,7 @@ class User < ActiveRecord::Base
   mount_uploader :image, AvaterUploader # CarrierWaveで作ったクラスと紐付ける
 
   validates :name, presence: true, length: { maximum: 50 }
-  validates :age, length: { maximum: 3 }, numericality: { only_integer: true }
+  validates :age, length: { maximum: 3 }, numericality: { only_integer: true, allow_nil: true }
   validates :self_introduction, length: { maximum: 200 }
 
   devise :database_authenticatable, :registerable,

--- a/api/spec/models/event_spec.rb
+++ b/api/spec/models/event_spec.rb
@@ -29,6 +29,10 @@ RSpec.describe Event, type: :model do
     expect(event.errors[:event_category]).to include('イベントカテゴリは半角数字で入力してください')
   end
 
+  it 'is allowed event_category value of nil' do
+    expect(FactoryBot.build(:event, event_category: nil)).to be_valid
+  end
+
   it 'is invalid without a start_date' do
     event = FactoryBot.build(:event, start_date: nil)
     event.valid?
@@ -51,6 +55,10 @@ RSpec.describe Event, type: :model do
     event = FactoryBot.build(:event, prefecture_id: 47)
     event.valid?
     expect(event.errors[:prefecture_id]).to include('都道府県IDは46以下の値にしてください')
+  end
+
+  it 'is allowed prefecture_id value of nil' do
+    expect(FactoryBot.build(:event, prefecture_id: nil)).to be_valid
   end
 
   it 'is invalid without a max_participants' do

--- a/api/spec/models/user_spec.rb
+++ b/api/spec/models/user_spec.rb
@@ -42,6 +42,10 @@ RSpec.describe User, type: :model do
     expect(user.errors[:age]).to include('年齢は半角数字で入力してください')
   end
 
+  it 'is allowed age value of nil' do
+    expect(FactoryBot.build(:user, age: nil)).to be_valid
+  end
+
   it 'is invalid with self_introduction length more than 200 characters' do
     user = FactoryBot.build(:user, self_introduction: 'a' * 201)
     user.valid?


### PR DESCRIPTION
validationのヘルパーメソッドであるnumericalityはデフォルトではnilが許容されていない為、フォーム送信時にエラー発生。
nilを許容しているカラムに対して、オプションを追加しました。
また、対象のモデルの項目に対して、nilを許容するかどうかのテストも併せて追加しました。 